### PR TITLE
Fixes NPE in dispose() method

### DIFF
--- a/JsonEditor/src/org/sweetlemonade/eclipse/json/outline/JsonOutlinePage.java
+++ b/JsonEditor/src/org/sweetlemonade/eclipse/json/outline/JsonOutlinePage.java
@@ -58,9 +58,9 @@ public class JsonOutlinePage extends ContentOutlinePage implements ISelectionLis
     @Override
     public void dispose()
     {
-        super.dispose();
-
         getSite().getPage().removePostSelectionListener(this);
+        
+        super.dispose();
     }
 
     @Override


### PR DESCRIPTION
After calling super.dispose() the site is set to null which causes a NPE in the call getSite().getPage(). Changed order of calls.